### PR TITLE
Updated to Crystal 0.23.0

### DIFF
--- a/src/toml/token.cr
+++ b/src/toml/token.cr
@@ -16,7 +16,7 @@ class TOML::Token
     @string_value = ""
     @int_value = 0_i64
     @float_value = 0.0
-    @time_value = Time.new(0_i64)
+    @time_value = Time.new(1,1,1)
   end
 
   def to_s(io)


### PR DESCRIPTION
Running on crystal-0.23.x failed. 

#### 0.22.x : Crystal 0.22.0 [3c71228] (2017-04-20) LLVM 3.5.0
```crystal
Time.new(0)       # => 0001-01-01 00:00:00
Time.new(1, 1, 1) # => 0001-01-01 00:00:00
```
#### 0.23.x : Crystal 0.23.0+228 [25392e1] (2017-10-04)
```crystal
Time.new(0)       # no overload matches 'Time.new' with type Int32
Time.new(1, 1, 1) # => 0001-01-01 00:00:00
```
This PR fixed it.

Thanks.
