### PR TITLE
Fix type restriction syntax in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ toml_string = %(
 toml = TOML.parse(toml_string)
 puts toml["title"] #=> "TOML Example"
 
-owner = toml["owner"] as Hash
+owner = toml["owner"].as(Hash)
 puts owner["name"] #=> "Lance Uppercut"
 puts owner["dob"]  #=> "1979-05-27 07:32:00 UTC"
 ```


### PR DESCRIPTION
The example defined in the README currently errors with:

```text
Syntax error in example.cr:14: unexpected token: as

owner = toml["owner"] as Hash
```

[This syntax](https://crystal-lang.org/docs/syntax_and_semantics/as.html) should be fixed.